### PR TITLE
feat: Enhance logging and validation for estimateFee

### DIFF
--- a/backend/src/RaffleBridgeImplementation.sol
+++ b/backend/src/RaffleBridgeImplementation.sol
@@ -509,7 +509,8 @@ contract RaffleBridgeImplementation is IUUPSUpgradeable {
         bool autoEnterRaffle
     ) external view returns (uint256 fee) {
         // 基本チェック
-        require(s_supportedChains[destinationChainSelector], "Destination chain not supported");
+        require(s_supportedChains[destinationChainSelector], "ERR:UNSUPPORTED_CHAIN");
+        require(s_usdcAddress != address(0), "ERR:USDC_ZERO_ADDR");
         
         // メッセージデータを準備
         bytes memory messageData = abi.encode(
@@ -528,8 +529,10 @@ contract RaffleBridgeImplementation is IUUPSUpgradeable {
         
         // 宛先チェーン用のルーターアドレスを取得
         address routerAddress = _getRouterForChain(destinationChainSelector);
+        require(routerAddress != address(0), "ERR:ROUTER_ZERO_ADDR");
         
         // CCIPメッセージを準備
+        require(s_destinationBridgeContracts[destinationChainSelector] != address(0), "ERR:DEST_BRIDGE_ZERO_ADDR");
         CCIPInterface.EVM2AnyMessage memory message = CCIPInterface.EVM2AnyMessage({
             receiver: abi.encode(s_destinationBridgeContracts[destinationChainSelector]),
             data: messageData,

--- a/frontend/hooks/use-token-bridge.ts
+++ b/frontend/hooks/use-token-bridge.ts
@@ -363,8 +363,33 @@ export function useTokenBridge() {
       
       setEstimatedFee(feeResult as bigint);
       return feeResult as bigint;
-    } catch (error) {
-      console.error("手数料見積もりエラー:", error);
+    } catch (error: any) {
+      console.error("手数料見積もりエラー詳細:");
+      console.error("  エラー名:", error.name);
+      console.error("  メッセージ:", error.message);
+      if (error.shortMessage) {
+        console.error("  短いメッセージ:", error.shortMessage);
+      }
+      if (error.cause) {
+        console.error("  原因:", error.cause);
+      }
+      if (error.meta) {
+        console.error("  メタ情報:", error.meta);
+      }
+
+      // estimateFee呼び出し時の引数をログ出力
+      const bridgeAddress = bridgeAddresses[currentChainId] as `0x${string}`;
+      const destinationSelector = chainSelectors[destinationChainId];
+      // USDC amount（デフォルトでは6デシマル）
+      const parsedAmount = parseUnits(amount, 6);
+
+      console.error("  estimateFee呼び出し引数:");
+      console.error(`    ソースブリッジコントラクトアドレス (bridgeAddress): ${bridgeAddress}`);
+      console.error(`    宛先セレクタ (destinationSelector): ${destinationSelector?.toString()}`);
+      console.error(`    ユーザーアドレス (activeAddress): ${activeAddress}`);
+      console.error(`    解析された金額 (parsedAmount): ${parsedAmount.toString()}`);
+      console.error(`    自動ラッフル参加 (autoEnterRaffle): ${autoEnterRaffle}`);
+      
       return null;
     }
   }, [activeAddress, currentChainId, publicClient]);


### PR DESCRIPTION
Improves debugging capabilities for fee estimation errors during bridging.

Frontend:
- Added detailed error logging in `useTokenBridge.ts` for `estimateBridgeFee` failures. This includes error properties (name, message, cause, etc.) and the arguments passed to the contract call to aid in diagnosing mismatches or RPC issues.

Backend:
- Added explicit require statements in `RaffleBridgeImplementation.sol`'s `estimateFee` function to validate:
    - Non-zero USDC address (`ERR:USDC_ZERO_ADDR`)
    - Non-zero destination bridge contract address (`ERR:DEST_BRIDGE_ZERO_ADDR`)
    - Non-zero CCIP router address (`ERR:ROUTER_ZERO_ADDR`)
- Standardized unsupported chain error message to `ERR:UNSUPPORTED_CHAIN`.

These changes will provide more specific error information if issues occur during the fee estimation process, helping to pinpoint the root cause more effectively.