### PR TITLE
fix: Correct CCIP router selection in RaffleBridge

### DIFF
--- a/backend/src/RaffleBridgeImplementation.sol
+++ b/backend/src/RaffleBridgeImplementation.sol
@@ -192,12 +192,14 @@ contract RaffleBridgeImplementation is IUUPSUpgradeable {
      * @return ルーターアドレス
      */
     function _getRouterForChain(uint64 chainSelector) internal view returns (address) {
-        address router = s_chainRouters[chainSelector];
-        // チェーン特有のルーターが設定されていない場合はデフォルトを使用
-        if (router == address(0)) {
-            return s_defaultRouter;
-        }
-        return router;
+        // The s_chainRouters mapping, as populated by the current deployer,
+        // maps destination chain selectors to routers ON THOSE DESTINATION CHAINS.
+        // This is not what we need for getFee/ccipSend, which must be called on the SOURCE chain's router.
+        // Therefore, we should always use s_defaultRouter, which is set to the current chain's router during initialization.
+        
+        // The chainSelector parameter is intentionally not used in this corrected logic.
+        // You can add `uint64 memory _ = chainSelector;` if needed to silence compiler warnings about unused parameters.
+        return s_defaultRouter; 
     }
 
     /**


### PR DESCRIPTION
`estimateFee` と `ccipSend` 関数は、以前は送信元チェーンではなく、送信先チェーンの CCIP ルータを使用しようとしていました。 これは、`_getRouterForChain`関数が宛先チェーンのセレクタに基づいて宛先チェーンのルータに不正に解決することが原因でした。

このコミットでは `_getRouterForChain` が常に `s_defaultRouter` を返すように修正され、ブリッジコントラクトが配置されているチェーンの CCIP ルータアドレスで正しく初期化されるようになりました。 これにより、すべての CCIP インタラクション (`getFee` や `ccipSend` など) がソースチェーンの正しいルータで実行されるようになります。

これにより、Arbitrum SepoliaからEthereum Sepoliaにブリッジする際に`estimateFee`で発生した`ContractFunctionExecutionError`が修正されました。